### PR TITLE
Adding getFilter function

### DIFF
--- a/lib/jira.js
+++ b/lib/jira.js
@@ -910,6 +910,46 @@ var JiraApi = exports.JiraApi = function(protocol, host, port, username, passwor
         });
     };
 
+    // ## Gets a filter on Jira ##
+    // ### Takes ###
+    //
+    // *  filterId: filter id
+    // *  callback: for when it's done
+    //
+    // ### Returns ###
+    //
+    // *  error: string if there's an error
+    // *  filter: a filter object
+    //
+    // [Jira Doc](https://docs.atlassian.com/jira/REST/latest/#d2e4424)
+    this.getFilter = function(filterId, callback) {
+        var options = {
+            rejectUnauthorized: this.strictSSL,
+            uri: this.makeUri('/filter/' + filterId),
+            method: 'GET',
+            json: true
+        };
+
+        this.doRequest(options, function(error, response, body) {
+
+            if (error) {
+                callback(error, null);
+                return;
+            }
+            if (response.statusCode === 200) {
+                callback(null, body);
+                return;
+            }
+            if (response.statusCode === 400) {
+                callback("Not found");
+                return;
+            }
+
+            callback(null, body);
+
+        });
+    };
+
     // ## Search user on Jira ##
     // ### Takes ###
     //


### PR DESCRIPTION
A **getFilter** function would be helpful to retrieve complex JQLs already on jira filters.